### PR TITLE
chore: fix lombok coverage

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+config.stopbubbling = true
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
Lombok generated methods are not recorded in test coverage